### PR TITLE
add a test which identifies a broken algorithm

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -27,4 +27,11 @@ describe('shuffle()', function() {
         assert.notDeepEqual(deck, shuffledDeck);
         assert.equal(deck.length, shuffledDeck.length);
     });
+
+    it('should not lose or duplicate elements', function() {
+        const d1 = [ 'A', 'B', 'C', 'D', 'E', 'F', 'G' ]
+        const d2 = shuffle(d1);
+        assert.includeMembers(d2, d1, 'all of original elements should be included in output')
+        assert.lengthOf(d2, d1.length, 'length of array should not change')
+    });
 });


### PR DESCRIPTION
I believe your implementation does not work. Here is a test which identifies this.

```
     AssertionError: all of original elements should be included in output: expected
[ 'A', 'B', 'B', 'A', 'A', 'A', 'A' ] to be a superset of
[ 'A', 'B', 'C', 'D', 'E', 'F', 'G' ]
```